### PR TITLE
(fix): Arrows-span right margin fix

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -161,6 +161,10 @@ ul {
 }
 
 @media only screen and (min-width: 20em) and (max-width: 64em) {
+  :root{
+    --sidebar-width: 350px;
+  }
+
   .app {
     main {
       button {

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -145,7 +145,7 @@ aside {
 
         .menu-toggle-wrap {
             top: -2.3rem;
-            right: 0.6rem;
+            //right: 0.6rem;
             margin-bottom: -1rem;
 
             .menu-toggle {


### PR DESCRIPTION
Quick sidebar fix, arrows icon margin was too much on mobile and made it overlap with the title.